### PR TITLE
chat by token

### DIFF
--- a/main/backend/capstone_project/capstone_project/middleware.py
+++ b/main/backend/capstone_project/capstone_project/middleware.py
@@ -1,0 +1,53 @@
+# myproject.myapi.utils.py
+from channels.auth import AuthMiddlewareStack
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import AnonymousUser
+
+from rest_framework.authtoken.models import Token
+from django.db import close_old_connections
+
+
+@database_sync_to_async
+def get_user(token_key):
+    try:
+        return Token.objects.get(key=token_key).user
+    except Token.DoesNotExist:
+        return AnonymousUser()
+
+
+class TokenAuthMiddleware:
+    """
+    Token authorization middleware for Django Channels 2
+    see:
+    https://channels.readthedocs.io/en/latest/topics/authentication.html#custom-authentication
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __call__(self, scope):
+        return TokenAuthMiddlewareInstance(scope, self)
+
+
+class TokenAuthMiddlewareInstance:
+    def __init__(self, scope, middleware):
+        self.middleware = middleware
+        self.scope = dict(scope)
+        self.inner = self.middleware.inner
+
+    async def __call__(self, receive, send):
+        close_old_connections()
+        headers = dict(self.scope["headers"])
+        print(headers[b"cookie"])
+        if b"authorization" in headers[b"cookie"]:
+            print('still good here')
+            cookies = headers[b"cookie"].decode()
+            token_key = re.search("authorization=(.*)(; )?", cookies).group(1)
+            if token_key:
+                self.scope["user"] = await get_user(token_key)
+
+        # inner = self.inner(self.scope)
+        return await self.inner(self.scope,receive, send) 
+
+
+TokenAuthMiddlewareStack = lambda inner: TokenAuthMiddleware(AuthMiddlewareStack(inner))

--- a/main/backend/capstone_project/capstone_project/routing.py
+++ b/main/backend/capstone_project/capstone_project/routing.py
@@ -3,9 +3,11 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 import chat.routing
 
+from .middleware import TokenAuthMiddlewareStack
+
 application = ProtocolTypeRouter({
     # (http->django views is added by default)
-    'websocket': AuthMiddlewareStack(
+    'websocket': TokenAuthMiddlewareStack(
         URLRouter(
             chat.routing.websocket_urlpatterns
         )

--- a/main/backend/capstone_project/chat/templates/chat/room.html
+++ b/main/backend/capstone_project/chat/templates/chat/room.html
@@ -13,10 +13,13 @@
 </body>
 
 <script>
-    var roomName = {{ room_name_json }};
+    // var roomName = {{ room_name_json }};
+    var roomName = "hello";
+    let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJ1c2VybmFtZSI6InRlc3QzIiwiZXhwIjoxNjE5NDE5MTg0LCJlbWFpbCI6ImFjZGFjZDY2QG5hdmVlci5jb20ifQ.lVf1FSXhykoFjM7PPZ8fFi6Iz6xnUZ9grsB8YxHYVPc";
+    document.cookie = 'authorization=' + token + ';' 
 
     var chatSocket = new WebSocket(
-        'ws://' + window.location.host +
+        'ws://' + "127.0.0.1:8000" +
         '/ws/chat/' + roomName + '/');
         
 


### PR DESCRIPTION
기존엔 chatting에 대한 user authentication을 session id를 client로부터 받아오는 식으로 가져온 반면 현제는 client로부터 토큰을 쿠키 형식으로 받아와서 authentication을 진행하는 방식으로 바꿈